### PR TITLE
Use body as root scrollable object instead of window

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ npm install scrollparent --save
 ## Example
 
 ```js
-Scrollparent(document.getElementById("content")) // window
+Scrollparent(document.getElementById("content")) // document.body
 ```
 
 ```js

--- a/scrollparent.js
+++ b/scrollparent.js
@@ -30,7 +30,7 @@
       }
     }
 
-    return window;
+    return document.body;
   };
 
   // If common js is defined use it.

--- a/test.html
+++ b/test.html
@@ -127,8 +127,8 @@ console.log("1..5");
 
 equal(Scrollparent(document.getElementById("test1")).className, "scroll");
 
-equal(Scrollparent(document.getElementById("test2")), window);
-equal(Scrollparent(document.getElementById("test3")), window);
+equal(Scrollparent(document.getElementById("test2")), document.body);
+equal(Scrollparent(document.getElementById("test3")), document.body);
 
 equal(Scrollparent(document.getElementById("test4")).className, "scroll-y");
 equal(Scrollparent(document.getElementById("test5")).className, "scroll-x");


### PR DESCRIPTION
`document.body.scrollTop` exists, while `window.scrollTop` does not. For that reason `document.body` should be returned rather than `window` as the root scrollable object.