### PR TITLE
Return scrollingElement || documentElement rather than body

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,20 @@ var Scrollparent = require("scrollparent");
 Scrollparent(document.getElementById("inside-a-scrolling-div")) // HTMLDivElement
 ```
 
+## Note about the root scrolling element
+
+Internally, the root scrolling element is determined in this library
+as the result of
+
+```js
+document.scrollingElement || document.htmlElement
+```
+
+This should give a usable result in most browsers today
+but if you want to ensure full support
+you should use a `document.scrollingElement` polyfill such as
+[this one](https://github.com/mathiasbynens/document.scrollingElement).
+
 ## Contributors
 
 * Ola Holmström (@olahol)

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ npm install scrollparent --save
 ```js
 var Scrollparent = require("scrollparent");
 
-Scrollparent(document.getElementById("content")) // document.body
+Scrollparent(document.getElementById("content")) // HTMLHtmlElement or HTMLBodyElement as appropriate
 ```
 
 ```js

--- a/scrollparent.js
+++ b/scrollparent.js
@@ -40,7 +40,7 @@
       }
     }
 
-    return document.body;
+    return document.scrollingElement || document.documentElement;
   };
 
   return scrollParent;

--- a/test.html
+++ b/test.html
@@ -127,8 +127,8 @@ console.log("1..5");
 
 equal(Scrollparent(document.getElementById("test1")).className, "scroll");
 
-equal(Scrollparent(document.getElementById("test2")), document.body);
-equal(Scrollparent(document.getElementById("test3")), document.body);
+equal(Scrollparent(document.getElementById("test2")), document.scrollingElement || document.documentElement);
+equal(Scrollparent(document.getElementById("test3")), document.scrollingElement || document.documentElement);
 
 equal(Scrollparent(document.getElementById("test4")).className, "scroll-y");
 equal(Scrollparent(document.getElementById("test5")).className, "scroll-x");


### PR DESCRIPTION
I feel like an idiot. In my last patch I switched this to `document.body`. But that's what `scrollTop` changes on in quirks mode. In standards mode it's supposed to change on the `html` element, `document.documentElement`. There are some inconsistencies between browsers, which is probably why I was confused, and to this day we as developers still have to test both. Chrome and Firefox do opposites.

[This](https://miketaylr.com/posts/2014/11/document-body-scrolltop.html) explains some of it, and even recommends checking a third place, `document.body.parentNode` -- not sure which browsers that's for. But as for what scrollparent.js should return, I'd say probably the one in the standards. See also this [Chrome dev thread](https://groups.google.com/a/chromium.org/forum/#!msg/blink-dev/75hVThfrJ08/YD9kSgQljFEJ), one of the posts of which points out `document.scrollingElement`, which is supported in some but not all browsers.

I think the best thing to return is the result of `document.scrollingElement || document.documentElement`, since that _should_ work in most cases.
